### PR TITLE
Set history to `false` if there were no changes done

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -41,6 +41,7 @@ function TextDirectionPlugin({ types }: { types: string[] }) {
 
       let modified = false;
       const tr = newState.tr;
+      tr.setMeta('addToHistory', false)
 
       newState.doc.descendants((node, pos) => {
         if (types.includes(node.type.name)) {


### PR DESCRIPTION
This way it will not be added to "redo / undo" actions, like:

![Test state loading of documents -- Initial content can not be undone (failed)](https://github.com/user-attachments/assets/c46e8f8a-86c0-4d13-9b1e-f6d1707b938b)
![Test state loading of documents -- Initial content can not be undone (failed) (attempt 2)](https://github.com/user-attachments/assets/a27a173d-a64e-46c0-86a2-94f5b57a69ba)


(the file was just loaded, no changes made)