### PR TITLE
Fix the extension name

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -183,7 +183,7 @@ export interface TextDirectionOptions {
  * - Avoids `dir="auto"`
  */
 export const TextDirection = Extension.create<TextDirectionOptions>({
-	name: "textDirection",
+	name: "tiptapTextDirection",
 
 	addOptions() {
 		return {


### PR DESCRIPTION
602472dd7f97f652dd3c8572dcb1f74a8b632006 didn't change the TipTap plugin name alongside the ProseMirror extension, so the duplicate message mentioned in #27 was still appearing.